### PR TITLE
Refactor login feature tests to use login helper

### DIFF
--- a/spec/features/user_can_login_spec.rb
+++ b/spec/features/user_can_login_spec.rb
@@ -17,11 +17,9 @@ RSpec.feature "Log in", type: :feature do
 
   scenario "Logging in succesfully takes you to the posts page" do
     visit "/"
-    sign_up email: 'myemail@gmail.com', password: 'mypassword'
+    sign_up
     click_link("Log out")
-
-    log_in email: 'myemail@gmail.com', password: 'mypassword'
-
+    log_in
     expect(page).to have_current_path("/posts")
   end
 
@@ -29,9 +27,7 @@ RSpec.feature "Log in", type: :feature do
     visit "/"
     sign_up email: 'myemail@gmail.com', password: 'mypassword'
     click_link("Log out")
-
     log_in email: 'wrongemail@gmail.com', password: 'mypassword'
-
     expect(page).to have_current_path("/login")
   end
 
@@ -39,27 +35,21 @@ RSpec.feature "Log in", type: :feature do
     scenario "user should not log in with an invalid password" do
       sign_up email: 'myemail@gmail.com', password: 'mypassword'
       click_link("Log out")
-
       log_in email: 'myemail@gmail.com', password: 'wrongpassword'
-
       expect(page).to have_content("Invalid password")
     end
 
     scenario "user should not log in with an empty password" do
       sign_up email: 'myemail@gmail.com', password: 'mypassword'
       click_link("Log out")
-
       log_in email: 'myemail@gmail.com', password: ''
-
       expect(page).to have_content("Invalid password")
     end
 
     scenario "user should be able to log in with the correct password" do
       sign_up email: 'myemail@gmail.com', password: 'mypassword'
       click_link("Log out")
-
       log_in email: 'myemail@gmail.com', password: 'mypassword'
-
       expect(page).to have_content("Logged in successfully")
     end
   end

--- a/spec/features/users_can_log_out_spec.rb
+++ b/spec/features/users_can_log_out_spec.rb
@@ -8,33 +8,8 @@ RSpec.feature "Log out", type: :feature do
     expect(page).not_to have_link("Log out")
   end
 
-  scenario "Log out should appear if user is logged in" do
-    visit "/"
-    fill_in "user[email_address]", with: "myemail@gmail.com"
-    fill_in "user[password]", with: "mypassword"
-    click_button "Sign up"
-
-    # once signing in actually logs you in we can delete this part:
-    visit "/login"
-    fill_in "Email address", with: "myemail@gmail.com"
-    fill_in "Password", with: "mypassword"
-    click_button "Log in"
-
-    expect(page).to have_link("Log out")
-  end
-
   scenario "Clicking log out should log you out" do
-    visit "/"
-    fill_in "user[email_address]", with: "myemail@gmail.com"
-    fill_in "user[password]", with: "mypassword"
-    click_button "Sign up"
-
-    # once signing in actually logs you in we can delete this part:
-    visit "/login"
-    fill_in "Email address", with: "myemail@gmail.com"
-    fill_in "Password", with: "mypassword"
-    click_button "Log in"
-
+    sign_up
     click_link("Log out")
     expect(page).not_to have_link("Log out")
   end


### PR DESCRIPTION
My test helper is called `log_in` which is the same name as a method
defined in the `ApplicationHelper`, but the tests are working so I guess
Rails is smart enough to tell them apart from context