### PR TITLE
REFACTOR: Give clarity to flash messages

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -9,7 +9,7 @@ class SessionsController < ApplicationController
   def create
     user = User.find_by(email: params[:session][:email_address].downcase)
     if user
-      if user && user.authenticate(params[:session][:password])
+      if user.authenticate(params[:session][:password])
         log_in(user)
         flash[:success] = "Logged in successfully"
         redirect_to posts_path

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -8,15 +8,19 @@ class SessionsController < ApplicationController
 
   def create
     user = User.find_by(email: params[:session][:email_address].downcase)
-
-    if user && user.authenticate(params[:session][:password])
-      log_in(user)
-      flash[:success] = "Logged in successfully"
-      redirect_to posts_path
+    if user
+      if user && user.authenticate(params[:session][:password])
+        log_in(user)
+        flash[:success] = "Logged in successfully"
+        redirect_to posts_path
+      else
+        flash[:danger] = "Invalid password"
+        redirect_to login_path
+        # show an error message
+      end
     else
-      flash[:danger] = "Invalid password"
+      flash[:danger] = "There isn't an account for this email address"
       redirect_to login_path
-      # show an error message
     end
   end
 

--- a/spec/features/user_can_login_spec.rb
+++ b/spec/features/user_can_login_spec.rb
@@ -45,8 +45,19 @@ RSpec.feature "Log in", type: :feature do
       log_in email: 'myemail@gmail.com', password: ''
       expect(page).to have_content("Invalid password")
     end
+  end
 
-    scenario "user should be able to log in with the correct password" do
+  context "Login email validation:-" do
+    scenario "user should not log in with an unknown email" do
+      sign_up email: 'myemail@gmail.com', password: 'mypassword'
+      click_link("Log out")
+      log_in email: 'notmyemail@gmail.com', password: 'mypassword'
+      expect(page).to have_content("There isn't an account for this email address")
+    end
+  end
+
+  context "Full credential validation:-" do
+    scenario "user should be able to log in with the correct credentials" do
       sign_up email: 'myemail@gmail.com', password: 'mypassword'
       click_link("Log out")
       log_in email: 'myemail@gmail.com', password: 'mypassword'

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe SessionsHelper do
   it "it creates a current user from the database" do
     user = double("User", id: 123)
     session[:user_id] = user.id
-    # mocking a database object in the sessions helper.
-    User = class_double("User")
-    allow(User).to receive(:find_by).with(id: session[:user_id]).and_return(user)
+    user_class = class_double("User").
+    as_stubbed_const(:transfer_nested_constants => true)
+    allow(user_class).to receive(:find_by).with(id: session[:user_id]).and_return(user)
     expect(current_user).to eq(user)
   end
 end


### PR DESCRIPTION
Add new flash message for when an account is not found in the database if user attempt to login with it
Fix test that was using real class name for a double name