### PR TITLE
some presentational tweaks and a link to the sign up form

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -81,12 +81,12 @@ body {
 
 #content {
   text-align: left;
-  width: 360px;
+  width: 500px;
   margin: 30px auto 0 auto;
 }
 
 #single_form {
-  margin-top: 110px;
+  margin: 110px 80px 0;
 }
 
 input[type=text], input[type=password], input[type=email] {
@@ -127,7 +127,7 @@ input[type=text], input[type=password], input[type=email] {
 }
 
 .new-post-button {
-  padding: 20px;
+  margin: 20px 0;
 }
 
 .alert {

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -3,5 +3,5 @@
   <%= form.label :message %>
   <%= form.text_field :message %>
 
-  <%= form.submit "Submit" %>
+  <%= form.submit "Submit", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -15,4 +15,8 @@
       <%= form.submit "Log in", class: "btn btn-primary" %>
     </p>
   <% end %>
+
+  <p>
+    Don't have an account? <%= link_to "Sign up for one here.", root_path %>
+  </p>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,6 +19,6 @@
   <% end %>
 
   <p>
-    Already signed up? <a href='/login'>Click here to log in.</a>
+    Already signed up? <%= link_to "Click here to log in.", login_path %>
   </p>
 </div>

--- a/spec/features/user_can_signup_spec.rb
+++ b/spec/features/user_can_signup_spec.rb
@@ -8,6 +8,19 @@ RSpec.feature "Sign up", type: :feature do
     expect(page).to have_current_path("/")
   end
 
+  context "You can get from the log in page to the sign up page" do
+    scenario "The log in page has a link to the sign up page" do
+      visit "/login"
+      expect(page).to have_link("Sign up for one here")
+    end
+
+    scenario "The link goes to the sign up page" do
+      visit "/login"
+      click_link("Sign up for one here")
+      expect(page).to have_current_path("/")
+    end
+  end
+
   scenario "Logged out users should get see a message when they get redirected" do
     visit "/posts/new"
     expect(page).to have_content("You must be logged in to access that page")
@@ -15,11 +28,11 @@ RSpec.feature "Sign up", type: :feature do
 
   scenario "Signup form should have email address and password fields" do
     visit "/"
-    expect(page).to have_field("user[email_address]")
-    expect(page).to have_field("user[password]")
+    expect(page).to have_field("Email address")
+    expect(page).to have_field("Password")
   end
 
-  scenario "Completing the signup form navigates to posts route" do
+  scenario "Completing the signup form navigates to posts page" do
     sign_up
     expect(page).to have_current_path("/posts")
   end
@@ -29,7 +42,7 @@ RSpec.feature "Sign up", type: :feature do
     expect(page).to have_link("Log out")
   end
 
-  scenario "After completing the signup form succesfully the user sees a confirmation mesage" do
+  scenario "A confirmation message is shown after the user signs up" do
     sign_up
     expect(page).to have_content("New account created")
   end


### PR DESCRIPTION
Three things:

- Make the standard content width wider so that posts look nice, but keep sign-up and log in pages the same narrower width
- Add a link from the log in page back to the sign-up page
- Add the button classes to the submit button on the new posts form so the standard styling is applied