### PR TITLE
Refactor sign-up error messages

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,8 @@ class ApplicationController < ActionController::Base
 
   include ApplicationHelper
 
-
   include SessionsHelper
-  include PostsHelper
-
+  
   private
 
     def require_login

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,7 +10,6 @@ class UsersController < ApplicationController
     email = params[:user][:email_address].downcase
     password = params[:user][:password]
 
-    user_with_same_email = User.find_by(email: email)
 
     user = User.new(email: email, password: password)
 
@@ -18,22 +17,11 @@ class UsersController < ApplicationController
       user.save
       session[:user_id] = user.id
       flash[:success] = "New account created"
-      redirect_to posts_path
+      redirect_to posts_path and return
     else
-      if user_with_same_email
-        flash[:danger] = "An account with this email already exists"
-      elsif user.errors.details[:email].include? ({:error=>:blank})
-        flash[:danger] = "Email field cannot be empty"
-      elsif user.errors[:email].any? 
-        flash[:danger] = "Invalid email address"
-      elsif user.errors.details[:password] == [{:error=>:too_short, :count=>6}]
-        flash[:danger] = "Password too short - must be 6-10 characters in length"
-      elsif user.errors.details[:password] == [{:error=>:too_long, :count=>10}]
-        flash[:danger] = "Password too long - must be 6-10 characters in length"
-      elsif user.errors.details[:password].include? ({:error=>:blank})
-        flash[:danger] = "Password field cannot be empty"
+      flash[:danger] = user.errors.full_messages.join("<br>")
     end
+
     redirect_to root_path
-    end
   end
 end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,7 +1,4 @@
 # frozen_string_literal: true
 
 module PostsHelper
-  def get_user_email(post)
-    User.find(post.user_id).email
-  end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -2,4 +2,5 @@
 
 class Post < ApplicationRecord
   belongs_to :user
+  delegate :email, :to => :user
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -36,7 +36,7 @@
     <div id="content">
       <div id="flash-messages" class="flash-message container">
         <% flash.each do |key, value| %>
-          <div class="alert alert-<%= key %>"><%= value %></div>
+          <div class="alert alert-<%= key %>"><%= value.html_safe %></div>
         <% end %>
       </div>
       <%= yield %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -11,9 +11,11 @@
   <div class='post-card'>
     <div class="post-header">
       <div class="post-author">
-        <%= get_user_email(post) %>
+        <%= post.email %>
       </div>
-      <div class="post-pubished-time"><%= post.created_at.strftime("%d-%m-%Y")%> at <%= post.created_at.strftime("%I:%M %p")%></div>
+      <div class="post-published-time">
+        <%= post.created_at.strftime("%d-%m-%Y")%> at <%= post.created_at.strftime("%I:%M %p")%>
+      </div>
     </div>
     <div class="post-content">
       <p><%= post.message %></p>

--- a/spec/features/user_can_signup_spec.rb
+++ b/spec/features/user_can_signup_spec.rb
@@ -50,56 +50,56 @@ RSpec.feature "Sign up", type: :feature do
   context "User must provide a valid email address" do
     scenario "User must provide an email address" do
       sign_up(email: "", password: "abc123")
-      expect(page).to have_content("Email field cannot be empty")
+      expect(page).to have_content("Email can't be blank")
     end
 
     scenario 'Email address must contain "@" symbol' do
       sign_up(email: "myemail", password: "abc123")
-      expect(page).to have_content("Invalid email address")
+      expect(page).to have_content("Email is invalid")
     end
 
     scenario "Email address must have a local part" do
       sign_up(email: "@myemail", password: "abc123")
-      expect(page).to have_content("Invalid email address")
+      expect(page).to have_content("Email is invalid")
     end
 
     scenario "Email address must have a domain" do
       sign_up(email: "myemail@", password: "abc123")
-      expect(page).to have_content("Invalid email address")
+      expect(page).to have_content("Email is invalid")
     end
 
     scenario "Email address must have a TLD" do
       sign_up(email: "myemail@domain", password: "abc123")
-      expect(page).to have_content("Invalid email address")
+      expect(page).to have_content("Email is invalid")
     end
 
     scenario "Email must be unique" do
       sign_up(email: "myemail@hotmail.com", password: "abc123")
       sign_up(email: "myemail@hotmail.com", password: "xyx789")
-      expect(page).to have_content("An account with this email already exists")
+      expect(page).to have_content("Email has already been taken")
     end
 
     scenario "Email must be unique disregarding case" do
       sign_up(email: "myemail@hotmail.com", password: "abc123")
       sign_up(email: "myemail@HOTMAIL.com", password: "xyx789")
-      expect(page).to have_content("An account with this email already exists")
+      expect(page).to have_content("Email has already been taken")
     end
   end
 
   context "User must provide a valid password" do
     scenario "User must provide a password" do
       sign_up(email: "myemail@hotmail.com", password: "")
-      expect(page).to have_content("Password field cannot be empty")
+      expect(page).to have_content("Password can't be blank")
     end
 
     scenario "Password must be at least 6 characters" do
       sign_up(email: "myemail@hotmail.com", password: "12345")
-      expect(page).to have_content("Password too short - must be 6-10 characters in length")
+      expect(page).to have_content("Password is too short (minimum is 6 characters)")
     end
 
     scenario "Password must be at most 10 characters" do
       sign_up(email: "myemail@hotmail.com", password: "1234567890a")
-      expect(page).to have_content("Password too long - must be 6-10 characters in length")
+      expect(page).to have_content("Password is too long (maximum is 10 characters)")
     end
   end
 end


### PR DESCRIPTION
We used `user.errors.full_messages` which gives you an array of
human-readable error messages, which was so simple we left
it in the controller and didn't refactor it into a helper after all.

Plus we refactored the posts index view to get the posts's author's
email address directly and deleted the helper method. Neater, and we
delegated the `.email` method from the post through to the post's
author in accordance with the [Law of Demeter](https://github.com/Hives/instagram-challenge/blob/master/docs/review.md#law-of-demeter-violations).

- Paul

