### PR TITLE
Restrict automatically generated routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,8 @@ Rails.application.routes.draw do
   delete "/logout", to: "sessions#destroy"
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :users
-  resources :posts
+  resources :users, only: [:create]
+  resources :posts, only: [:index, :new, :edit, :create, :update, :destroy]
 
   root "users#new"
 end


### PR DESCRIPTION
We were automatically generating all routes for our users and posts
resources, some of which were unnecessary. So I've restricted the number
of routes generated to what we are actually using. This is in line with
Rails best practices, and cuts down on memory usage, speeding up the
routing process.

I've reduced the total number of routes from 20 to 12.

https://rails-bestpractices.com/posts/2011/08/19/restrict-auto-generated-routes/