### PR TITLE
CHANGE posts table column name user_id to author_id

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,7 +11,7 @@ class PostsController < ApplicationController
 
   def edit
     @post = Post.find(params[:id])
-    if @post.user_id != current_user.id
+    if @post.author_id != current_user.id
       flash[:danger] = "You can't edit that post!"
       redirect_to posts_path
     end
@@ -19,7 +19,7 @@ class PostsController < ApplicationController
 
   def destroy
     post = Post.find(params[:id])
-    if post.user_id == current_user.id
+    if post.author_id == current_user.id
       post.destroy
       flash[:success] = "Post deleted"
       redirect_to posts_path
@@ -29,7 +29,7 @@ class PostsController < ApplicationController
   def create
     user = current_user
     params = post_params
-    params[:user_id] = user.id
+    params[:author_id] = user.id
     @post = Post.create(params)
     redirect_to posts_url
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
-  belongs_to :user
-  delegate :email, :to => :user
+  belongs_to :author, :class_name => "User"
+  delegate :email, :to => :author
   
   def editable?
     less_than_ten_minutes_old?

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -19,7 +19,7 @@
     </div>
     <div class="post-content">
       <p><%= simple_format(post.message) %></p>
-      <% if post.user_id == current_user.id %>
+      <% if post.author_id == current_user.id %>
         <% if post.editable? %>
           <p><%= link_to 'Edit', edit_post_path(post) %></p> 
         <% end %>

--- a/db/migrate/20190430132944_change_post_user_id_to_author_id.rb
+++ b/db/migrate/20190430132944_change_post_user_id_to_author_id.rb
@@ -1,0 +1,6 @@
+class ChangePostUserIdToAuthorId < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :posts, :user_id, :author_id
+    add_foreign_key :posts, :users, column: :author_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190425132704) do
+ActiveRecord::Schema.define(version: 20190430132944) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,8 +19,8 @@ ActiveRecord::Schema.define(version: 20190425132704) do
     t.string "message"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
-    t.index ["user_id"], name: "index_posts_on_user_id"
+    t.bigint "author_id"
+    t.index ["author_id"], name: "index_posts_on_author_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -30,4 +29,6 @@ ActiveRecord::Schema.define(version: 20190425132704) do
     t.datetime "updated_at", null: false
     t.string "password_digest"
   end
+
+  add_foreign_key "posts", "users", column: "author_id"
 end

--- a/spec/controllers/posts_controller_spec.rb
+++ b/spec/controllers/posts_controller_spec.rb
@@ -15,24 +15,16 @@ RSpec.describe PostsController, type: :controller do
     it "responds with 200" do
       user = User.create(email: "test@email.com", password: "123456")
       session[:user_id] = user.id
-      post :create, params: { post: { message: "Hello, world!", user_id: session[:user_id] } }
+      post :create, params: { post: { message: "Hello, world!", author_id: session[:user_id] } }
       expect(response).to redirect_to(posts_url)
     end
-
-    # seems like this is a nothing test - no expectation?
-    # it "creates a post" do
-    #   user = User.create(email: "test@email.com", password: "123456")
-    #   session[:user_id] = user.id
-    #   post :create, params: { post: { message: "Hello, world!", user_id: session[:user_id] } }
-    #   expect(Post.find_by(message: "Hello, world!")).to be
-    # end
 
     it "post has a user_id" do
       user = User.create(email: "test@email.com", password: "123456")
       session[:user_id] = user.id
-      post :create, params: { post: { message: "Hello, world!", user_id: session[:user_id] } }
+      post :create, params: { post: { message: "Hello, world!", author_id: session[:user_id] } }
       check = Post.find_by(message: "Hello, world!")
-      expect(check.user_id).to be(session[:user_id])
+      expect(check.author_id).to be(session[:user_id])
     end
   end
 

--- a/spec/features/posts_can_be_modified_by_their_owners_spec.rb
+++ b/spec/features/posts_can_be_modified_by_their_owners_spec.rb
@@ -36,7 +36,7 @@ RSpec.feature "Editing posts", type: :feature do
 
   scenario "Users can't edit other users' posts" do
     user = User.create(email: "my@email.com", password: "123456")
-    post = Post.create(message: "my message", user_id: user.id)
+    post = Post.create(message: "my message", author_id: user.id)
 
     sign_up
     visit "/posts/#{post.id}/edit"

--- a/spec/models/post_spec.rb
+++ b/spec/models/post_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe Post, type: :model do
   describe "editable?" do
     it "returns true if a post is less than ten minutes old" do
       u = User.create(email: "my@email.address", password: "password")
-      p = Post.create(message: "Hello", user_id: u.id)
+      p = Post.create(message: "Hello", author_id: u.id)
       p.created_at = 9.minutes.ago
       expect(p.editable?).to be true
     end
 
     it "returns false if a post is ten minutes old" do
       u = User.create(email: "my@email.address", password: "password")
-      p = Post.create(message: "Hello", user_id: u.id)
+      p = Post.create(message: "Hello", author_id: u.id)
       p.created_at = 10.minutes.ago
       expect(p.editable?).to be false
     end


### PR DESCRIPTION
New db migrate file written, renames colum
Then adds specific foreign key association with author_id
Manually adding foreign key association is vital due to the rails automatic reference index assuming the column name is user_id
post model belongs to author but User class has to be specified in order to inherit object
Tests all passing after changing relevant names