### PR TITLE
REFACTOR: Adding css to links to show as button

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -114,6 +114,7 @@ textarea {
   padding: 10px;
   display: inline-flex;
   font: inherit;
+  text-decoration: none;
   border: 1px solid #c3c3c3;
   border-radius: 5px;
 }
@@ -130,17 +131,20 @@ textarea {
   background: linear-gradient(#94d27b, #578843);
 }
 
-.btn-add-delete {
+.btn-edit-post {
   -webkit-appearance: none;
   appearance: none;
-  padding: 5px;
-  display: inline-flex;
-  background-color: #4267b2;
+  padding: 4px 5px 5px 5px;
+  font-size: 0.7rem;
+
+  border-color: #8b9dc3;
+
+  background: linear-gradient(#8b9dc3, #3b5998);
   color: white;
-  font: inherit;
-  border: 1px solid #c3c3c3;
-  border-radius: 5px;
-  text-decoration: none;
+}
+
+.btn-edit-post:hover {
+  background: linear-gradient(#acbde0, #3b5998);
 }
 
 .new-post-button {
@@ -169,6 +173,7 @@ textarea {
 /* <p2> font-family: 'Faster One', cursive; */
 
 .post-card {
+  font-size: 0.9rem;
   background-color:white;
   border: 1px solid #d0d1d5;
   border-radius:3px;
@@ -184,22 +189,14 @@ textarea {
 }
 
 .post-author {
-  font-size:14px;
   font-weight: bold;
-  line-height: 1.38;
   color: #365899;
   text-decoration:none;
   margin-bottom:2px;
 }
 
-.post-pubished-time {
+.post-published-time {
+  font-size: 0.8rem;
   font-family: Helvetica;
-  font-size:12px;
   color: #90949c;
-}
-
-.post-content {
-  clear:both;
-  font-size:14px;
-  line-height: 1.38;
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -130,6 +130,19 @@ textarea {
   background: linear-gradient(#94d27b, #578843);
 }
 
+.btn-add-delete {
+  -webkit-appearance: none;
+  appearance: none;
+  padding: 5px;
+  display: inline-flex;
+  background-color: #4267b2;
+  color: white;
+  font: inherit;
+  border: 1px solid #c3c3c3;
+  border-radius: 5px;
+  text-decoration: none;
+}
+
 .new-post-button {
   margin: 20px 0;
 }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Posts page</h1>
 
 <div class="new-post-button">
-  <%= link_to new_post_path do %>
+  <%= link_to new_post_path, class: "btn-add-delete" do %>
     Create new post
   <% end %>
 </div>
@@ -23,7 +23,7 @@
         <% if post.editable? %>
           <p><%= link_to 'Edit', edit_post_path(post) %></p> 
         <% end %>
-        <p><%= link_to 'Delete', post, method: :delete, :data => { :confirm => "Are you sure you want to delete this message?" } %></p> 
+        <p><%= link_to 'Remove', post, method: :delete, :data => { :confirm => "Are you sure you want to delete this message?" }, class: "btn-add-delete" %></p>
       <% end %>
     </div>
   </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,7 @@
 <h1>Posts page</h1>
 
 <div class="new-post-button">
-  <%= link_to new_post_path, class: "btn-add-delete" do %>
+  <%= link_to new_post_path, class: "btn btn-primary" do %>
     Create new post
   <% end %>
 </div>
@@ -19,11 +19,13 @@
     </div>
     <div class="post-content">
       <p><%= simple_format(post.message) %></p>
+    </div>
+    <div class="post-edit-options">
       <% if post.author_id == current_user.id %>
         <% if post.editable? %>
-          <p><%= link_to 'Edit', edit_post_path(post) %></p> 
+          <%= link_to 'Edit', edit_post_path(post), class: "btn btn-edit-post" %>
         <% end %>
-        <p><%= link_to 'Remove', post, method: :delete, :data => { :confirm => "Are you sure you want to delete this message?" }, class: "btn-add-delete" %></p>
+        <%= link_to 'Remove', post, method: :delete, :data => { :confirm => "Are you sure you want to delete this message?" }, class: "btn btn-edit-post" %>
       <% end %>
     </div>
   </div>

--- a/spec/features/posts_can_be_deleted_spec.rb
+++ b/spec/features/posts_can_be_deleted_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature "Deleting posts", type: :feature do
   scenario "A 'delete' link should appear on a user's post" do
     sign_up
     create_post
-    expect(page).to have_link("Delete")
+    expect(page).to have_link("Remove")
   end
 
   scenario "An 'delete' link should not appear on a different user's post" do
@@ -14,7 +14,7 @@ RSpec.feature "Deleting posts", type: :feature do
     create_post
     sign_up email: "user2@gmail.com"
     visit "/posts"
-    expect(page).not_to have_link("Delete")
+    expect(page).not_to have_link("Remove")
   end
 
   context "When a user clicks 'delete' on their post" do
@@ -22,7 +22,7 @@ RSpec.feature "Deleting posts", type: :feature do
       sign_up email: "user1@gmail.com"
       create_post
       expect(page).to have_content("Hello m0m")
-      click_link('Delete')
+      click_link('Remove')
     end
 
     scenario "The post gets deleted" do


### PR DESCRIPTION
Facebook has the 'remove' button, not a 'delete' link, so have applied a naming change to
reflect this, have also made the link look like a button with some css, so it looks nice!
Have applied the same color as the banner for conformity.