### PR TITLE
Fix/make posts belong to recipient

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -22,15 +22,6 @@ class PostsController < ApplicationController
     end
   end
 
-  def destroy
-    post = Post.find(params[:id])
-    if post.author == current_user
-      post.destroy
-      flash[:success] = "Post deleted"
-      redirect_to "/#{current_user.username}"
-    end
-  end
-
   def create
     post = Post.create(post_params.merge(author_id: current_user.id))
     redirect_to "/#{post.recipient_username}"
@@ -41,13 +32,22 @@ class PostsController < ApplicationController
 
     unless post.editable?
       flash[:danger] = "Could not edit post. Posts are only editable for 10 minutes."
-      redirect_to "/#{post.recipient_username}" and return
+      return redirect_to "/#{post.recipient_username}"
     end
 
     if post.update(post_params.merge(recipient_id: post.recipient_id))
       redirect_to "/#{post.recipient_username}"
     else
       render "edit"
+    end
+  end
+
+  def destroy
+    post = Post.find(params[:id])
+    if post.author == current_user
+      post.destroy
+      flash[:success] = "Post deleted"
+      redirect_to "/#{current_user.username}"
     end
   end
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -16,7 +16,7 @@ class PostsController < ApplicationController
 
   def edit
     @post = Post.find(params[:id])
-    if @post.author_id != current_user.id
+    if @post.author != current_user
       flash[:danger] = "You can't edit that post!"
       redirect_to "/#{current_user.username}"
     end
@@ -24,7 +24,7 @@ class PostsController < ApplicationController
 
   def destroy
     post = Post.find(params[:id])
-    if post.author_id == current_user.id
+    if post.author == current_user
       post.destroy
       flash[:success] = "Post deleted"
       redirect_to "/#{current_user.username}"
@@ -32,22 +32,20 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.create(post_params.merge(author_id: current_user.id))
-    recipient = User.find(post_params[:recipient_id])
-    redirect_to "/#{recipient.username}"
+    post = Post.create(post_params.merge(author_id: current_user.id))
+    redirect_to "/#{post.recipient_username}"
   end
 
   def update
     post = Post.find(params[:id])
-    recipient = User.find(post.recipient_id)
 
     unless post.editable?
       flash[:danger] = "Could not edit post. Posts are only editable for 10 minutes."
-      redirect_to "/#{recipient.username}" and return
+      redirect_to "/#{post.recipient_username}" and return
     end
 
-    if post.update(post_params.merge(recipient_id: recipient.id))
-      redirect_to "/#{recipient.username}"
+    if post.update(post_params.merge(recipient_id: post.recipient_id))
+      redirect_to "/#{post.recipient_username}"
     else
       render "edit"
     end
@@ -55,7 +53,7 @@ class PostsController < ApplicationController
 
   private
 
-    def post_params
-      params.require(:post).permit(:message, :recipient_id)
-    end
+  def post_params
+    params.require(:post).permit(:message, :recipient_id)
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < ApplicationController
 
     if user.valid?
       user.save
-      session[:user_id] = user.id
+      log_in(user)
       flash[:success] = "New account created"
       redirect_to "/#{current_user.username}" and return
     else

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
 class Post < ApplicationRecord
-  belongs_to :author, :class_name => "User"
-  delegate :email, :to => :author
-  delegate :username, :to => :author
-  
+  belongs_to :author, class_name: "User"
+  delegate :username, to: :author, prefix: :author
+
+  belongs_to :recipient, class_name: "User"
+  delegate :username, to: :recipient, prefix: :recipient
+  delegate :id, to: :recipient, prefix: :recipient
+
   def editable?
     less_than_ten_minutes_old?
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -19,7 +19,7 @@
         <ul>
           <% if session[:user_id] %>
             <li>
-              <%= link_to "View posts", posts_path %>
+              <%= link_to "My wall", "/#{current_user.username}" %>
             </li>
             <li>
               <%= link_to "Log out", logout_path, method: :delete %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -6,7 +6,7 @@
 
 <div class="new-post-button">
   <% if @user %>
-    <%= link_to new_post_path recipient_id: @user.id, class: "btn btn-primary" do %>
+    <%= link_to new_post_path(recipient_id: @user.id), class: "btn btn-primary" do %>
       Create new post
     <% end %>
   <% end %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,23 +1,16 @@
-<% if @user %>
-  <h1><%= @user.username.capitalize %>'s Wall</h1>
-<% else %>
-  <h1>Posts</h1>
-<% end %>
+<h1><%= @user.username.capitalize %>'s Wall</h1>
 
 <div class="new-post-button">
-  <% if @user %>
-    <%= link_to new_post_path(recipient_id: @user.id), class: "btn btn-primary" do %>
-      Create new post
-    <% end %>
+  <%= link_to new_post_path(recipient_id: @user.id), class: "btn btn-primary" do %>
+    Create new post
   <% end %>
 </div>
 
 <% @posts.each do |post| %>
-
   <div class='post-card'>
     <div class="post-header">
       <div class="post-author">
-        <%= post.username %>
+        <%= post.author_username %>
       </div>
       <div class="post-published-time">
         <%= post.created_at.strftime("%d-%m-%Y")%> at <%= post.created_at.strftime("%I:%M %p")%>
@@ -27,7 +20,7 @@
       <p><%= simple_format(post.message) %></p>
     </div>
     <div class="post-edit-options">
-      <% if post.author_id == current_user.id %>
+      <% if post.author == current_user %>
         <% if post.editable? %>
           <%= link_to 'Edit', edit_post_path(post), class: "btn btn-edit-post" %>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :users, only: [:create]
-  resources :posts, only: [:index, :new, :edit, :create, :update, :destroy]
+  resources :posts, only: [:new, :edit, :create, :update, :destroy]
 
   root "users#new"
 

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -3,21 +3,21 @@
 require "rails_helper"
 
 RSpec.feature "Nav bar", type: :feature do
-  describe "'View posts'" do
-    scenario "Logged in users should see a link to posts page" do
+  describe "'My wall'" do
+    scenario "Logged in users should see a link to their wall" do
       sign_up
-      expect(page).to have_link("View posts")
+      expect(page).to have_link("My wall")
     end
 
-    scenario "'View posts' link should go to posts page" do
-      sign_up
-      click_link("View posts")
-      expect(current_path).to eq "/posts"
+    scenario "'My wall' link should go to posts page" do
+      sign_up username: "user"
+      click_link("My wall")
+      expect(current_path).to eq "/user"
     end
 
-    scenario "Logged out users do not see posts link" do
+    scenario "Logged out users do not see 'My wall'sposts link" do
       visit "/"
-      expect(page).not_to have_link("View posts")
+      expect(page).not_to have_link("My wall")
     end
   end
 

--- a/spec/features/nav_bar_spec.rb
+++ b/spec/features/nav_bar_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature "Nav bar", type: :feature do
       expect(current_path).to eq "/user"
     end
 
-    scenario "Logged out users do not see 'My wall'sposts link" do
+    scenario "Logged out users do not see 'My wall' link" do
       visit "/"
       expect(page).not_to have_link("My wall")
     end

--- a/spec/features/posts_can_be_modified_by_their_owners_spec.rb
+++ b/spec/features/posts_can_be_modified_by_their_owners_spec.rb
@@ -68,18 +68,18 @@ RSpec.feature "Editing posts", type: :feature do
 
   context "Presence of the edit link depends on the post's age" do
     scenario "The edit link doesn't appear if a post is 10 minutes old" do
-      sign_up
-      create_post
+      sign_up username: "user"
+      create_post on_wall_of: "user"
       Timecop.freeze(601)
-      visit "/posts"
+      visit "/user"
       expect(page).not_to have_link("Edit")
     end
 
     scenario "The edit link does appear if it's less than 10 minutes old" do
-      sign_up
-      create_post
+      sign_up username: "user"
+      create_post on_wall_of: "user"
       Timecop.freeze(599)
-      visit "/posts"
+      visit "/user"
       expect(page).to have_link("Edit")
     end
   end

--- a/spec/features/posts_can_be_modified_by_their_owners_spec.rb
+++ b/spec/features/posts_can_be_modified_by_their_owners_spec.rb
@@ -56,10 +56,12 @@ RSpec.feature "Editing posts", type: :feature do
   scenario "Users can't edit other users' posts" do
     # not very feature testy!
     # maybe this should be a unit test on the route???
-    user1 = User.create(username: "user1",
+    user1 = User.create username: "user1",
                         email: "user1@gmail.com",
-                        password: "123456")
-    post = Post.create(message: "my message", author_id: user1.id)
+                        password: "123456"
+    post = Post.create message: "my message",
+                       author_id: user1.id,
+                       recipient_id: user1.id
 
     sign_up username: "user2", email: "user2@gmail.com"
     visit "/posts/#{post.id}/edit"

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe SessionsHelper do
   end
 
   describe "#current_user" do
-  it "it creates a current user from the database" do
-    user = double("User", id: 123)
-    session[:user_id] = user.id
-    user_class = class_double("User").
-    as_stubbed_const(transfer_nested_constants: true)
-    allow(user_class).to receive(:find_by).with(id: session[:user_id]).and_return(user)
-    expect(current_user).to eq(user)
+    it "it creates a current user from the database" do
+      user = double("User", id: 123)
+      session[:user_id] = user.id
+      user_class = class_double("User").
+      as_stubbed_const(transfer_nested_constants: true)
+      allow(user_class).to receive(:find_by).with(id: session[:user_id]).and_return(user)
+      expect(current_user).to eq(user)
+    end
   end
-end
 end


### PR DESCRIPTION
**MERGE THE OTHER PULL REQUEST (remove '/posts' route) BEFORE THIS ONE!**
I merged that one into this one already, so it makes more sense to
review the other one first.

---

In the posts model we can say a post `belongs_to: recipient`, after
which we can call `post.recipient` to get the recipient user. This allows
us to refactor in various places where we were getting the recipient out
of the database manually.

We can also set up the `post` model to pass `.recipient_id` and
`.recipient_username` through to the `recipient`, which lets us refactor a
couple of other places for readability.

Plus we can remove a couple of conditionals in the post index view now
that you can only get there by specifying a particular user's wall,
since we removed the '/posts' route.

A couple of other minor things too.