### PR TITLE
Set `recipient_id` hidden field correctly in `post/edit`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,7 @@ group :development, :test do
   gem "capybara", "~> 2.13"
   gem "launchy"
   gem "orderly"
+  gem "pry"
   gem "rspec-rails", "~> 3.5"
   # for linting.
   gem "rubocop"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,7 @@ GEM
       xpath (>= 2.0, < 4.0)
     childprocess (1.0.1)
       rake (< 13.0)
+    coderay (1.1.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
     diff-lcs (1.3)
@@ -105,6 +106,9 @@ GEM
     parser (2.6.2.1)
       ast (~> 2.4.0)
     pg (1.1.4)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     psych (3.1.0)
     public_suffix (3.0.3)
     puma (3.12.1)
@@ -236,6 +240,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   orderly
   pg
+  pry
   puma (~> 3.7)
   rails (~> 5.1.1)
   rspec-rails (~> 3.5)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -35,7 +35,7 @@ class PostsController < ApplicationController
       return redirect_to "/#{post.recipient_username}"
     end
 
-    if post.update(post_params.merge(recipient_id: post.recipient_id))
+    if post.update(post_params)
       redirect_to "/#{post.recipient_username}"
     else
       render "edit"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,7 +6,6 @@ class Post < ApplicationRecord
 
   belongs_to :recipient, class_name: "User"
   delegate :username, to: :recipient, prefix: :recipient
-  delegate :id, to: :recipient, prefix: :recipient
 
   def editable?
     less_than_ten_minutes_old?

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,7 +1,6 @@
-
 <%= form_for @post do |form| %>
   <%= form.label :message %>
   <%= form.text_area :message %>
-  <%= form.hidden_field :recipient_id, value: params[:recipient_id] %>
+  <%= form.hidden_field :recipient_id, value: @post.recipient_id || params[:recipient_id] %>
   <%= form.submit "Submit", class: "btn btn-primary" %>
 <% end %>


### PR DESCRIPTION
For an already-exisiting post we use `@post.recipient_id`, and if that
doesn't exist, i.e. for a newly-created post, we get it from the params.

This means we can do `post.update(post_params)` in `posts#update` and be
sure we'll have all the necessary fields in there.

I've also added Pry to the Gemfile - a badass ruby debugger. Get to know! <https://github.com/pry/pry>